### PR TITLE
fixes `--ignore-tab-space-mix` and `--quiet` mode

### DIFF
--- a/wtf.py
+++ b/wtf.py
@@ -92,7 +92,7 @@ def parse_args():
 
     g=p.add_argument_group("Tabs")
     multi_opt(g, '-s', '--tab-space-mix', default='report', help='Warn if spaces followed by tabs in whitespace at beginning of line (default %(default)s)',
-              values=('report','ignore'), longs=('','ignore-'),shorts=('','I'))
+              values=('report',None), longs=('','ignore-'),shorts=('','I'))
     g.add_argument('-x', '--change-tabs', metavar='SPACES', default=None, type=int, help='Change leading tabs to spaces')
 
     g = p.add_mutually_exclusive_group()


### PR DESCRIPTION
Prior to this fix using --ignore-tab-space-mix would not work
properly and subsequently the --quiet mode as well.

**Currently `--ignore-tab-space-mix` does not behave:**

``` bash
./wtf.py \
--dry-run \
--ignore-trail-space \
--ignore-eof-blanks \
--ignore-eof-newl \
--ignore-match-eol \
--ignore-tab-space-mix \
nightmare.txt

nightmare.txt LINE 8: WARNING: spaces followed by tabs in whitespace at beginning of line
nightmare.txt:
        WARNED ABOUT 1 lines with tabs/spaces mix
```

**even when using `--quiet`**

``` bash
./wtf.py \
--quiet \
--dry-run \
--ignore-trail-space \
--ignore-eof-blanks \
--ignore-eof-newl \
--ignore-match-eol \
--ignore-tab-space \
nightmare.txt

nightmare.txt LINE 8: WARNING: spaces followed by tabs in whitespace at beginning of line
```
