### PR TITLE
Add --expect-eol option to report non-matching line-endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,14 @@ enabling the user to fix, report, or ignore the issue.
   characters by making them all the same as the first line of the
   file. The desired EOL markers can also be set to a specific value
   (lf/crlf/native), in which case all lines will unconditionally
-  receive this marker.
+  receive this marker. Additionally `--expect-eol` can be used to
+  report line endings not matching the value set (lf/crlf/native).
 
         -m, --match-eol
         -M, --report-match-eol
         -Im, --ignore-match-eol
         -E ENDING, --coerce-eol ENDING
+        --expect-eol ENDING
 
 * Check for spaces followed by tabs in the whitespace at the beginning
   of a line; fixing this condition requires setting either


### PR DESCRIPTION
Reports line endings not matching a specific type: crlf, lf, or native (default none). Resolves: https://github.com/dlenski/wtf/issues/4

**Examples:**

``` bash
$ ./wtf.py -0 -It -Ib -In -Is -Im --expect-eol=lf nightmare.txt
nightmare.txt:
        SAW 13 line endings not matching lf

$ ./wtf.py -0 -It -Ib -In -Is -Im --expect-eol=crlf nightmare.txt
nightmare.txt:
        SAW 2 line endings not matching crlf
```
