### PR TITLE
Fix crash in `wtf -v` of zero-byte files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = LF

--- a/wtf.py
+++ b/wtf.py
@@ -147,6 +147,9 @@ class FileProcessor(object):
         self.seen = slurpy((k,0) for k in actions)
         self.fixed = slurpy((k,0) for k in actions)
 
+        # whether the file was empty
+        self.empty_file = True
+
     # reads from .inf, writes to .outf
     # yield messages along the way: (verbosity, line, empty, message)
     def run(self):
@@ -165,6 +168,8 @@ class FileProcessor(object):
             assert actions.change_spaces or actions.change_tabs
 
         for ii,line in enumerate(self.inf):
+            self.empty_file = False
+
             # Take the line apart
             m = self.lre.match(line)
             ispace, body, trail, eol = m.groups()
@@ -259,6 +264,8 @@ class FileProcessor(object):
                     buffer = []
                 self.outf.write(outline)
 
+        # end of loop over each line
+
         # handle blank lines at end
         if buffer:
             # we have leftover lines ...
@@ -317,7 +324,13 @@ for inf in args.inf:
     problems_seen = sum( seen[k] for k in actions )
     all_seen += problems_seen
     all_fixed += sum( fixed[k] for k in actions )
-    if args.verbose>=1:
+
+    if args.verbose>=2 and fp.empty_file:
+        print("%s:\n\tempty file - no action taken" % fname, file=stderr)
+        # Can't do the full --verbose output, because not all the fp
+        # instance variables have been initialized.
+
+    elif args.verbose>=1:
         if problems_seen>0 or args.verbose>=2:
             print("%s:" % fname, file=stderr)
             if actions.trail_space:


### PR DESCRIPTION
I saw the following failure:

    $ touch foo.swp
    $ ./wtf -0v foo.swp
    foo.swp:
            CHOPPED 0 lines with trailing space
            CHOPPED 0 blank lines at EOF
            no change to newline at EOF
    Traceback (most recent call last):
      File "./wtf", line 331, in <module>
        eol_val2name[fp.eol_value], ' from first line' if actions.coerce_eol[1]=='first' else ''), file=stderr)
    KeyError: None

It appears that, for zero-byte files, `fp.eol_value` is never changed from `None`.  This makes sense, because there is no first line to pull the EOL from in a zero-byte file.  This is only a problem in `-v`, since otherwise `fp.eol_value` is never queried while processing a zero-byte file without `-v`.

This PR adds a specific check for empty files.  If the file is empty, the PR version gives the output:

    $ ./wtf -0v foo.swp
    foo.swp:
            empty file - no action taken

and no crash.

This PR also adds a [`.editorconfig` file](https://editorconfig.org) to activate the project coding style (4 spaces, LF) in editors that support EditorConfig.

Thanks for considering this PR!