### PR TITLE
use git-check-attr to skip files marked +binary or -text

### DIFF
--- a/pre-commit.careful
+++ b/pre-commit.careful
@@ -10,6 +10,9 @@ while read -d '' _ MODE _ SHA1 _ && read -d '' FILE
 do
     if [ "$MODE" == 120000 ]; then
         true # ignore symlinks
+    elif git check-attr -a -- "$FILE" | grep -Eq ': (binary: set|text: unset)$'; then
+         # ignore files marked as binary or non-text; see gitattributes(5) and git-check-attr(1)
+        echo "No whitespace checking for file '$FILE'; marked +binary or -text"
     elif ! ( git cat-file blob $SHA1 | wtf $wtf_options > $tmp ); then
         if [ -s $tmp ]; then
             git update-index --cacheinfo $MODE $(git hash-object -w $tmp) "$FILE"


### PR DESCRIPTION
ping #22

* [`check-attr`](https://git-scm.com/docs/git-check-attr) was added in git 2.6.7: should we check for older versions and skip gracefully?
* `check-attr` doesn't appear to work correctly with specific named attributes with Git 2.17.1 :-1: :-1: (always returns `unspecified`), hence need to use `-a` and `grep`
* Should the `No whitespace checking` message be removed?
* Should the `--cached` flag be added, so that we only `check-attr` against `.gitattributes` _as set in the index_? I think not.